### PR TITLE
copy my.cnf for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
   - 1.8
   - tip
 
+before_install:
+  - sudo cp /etc/mysql/my.cnf /usr/share/mysql/my-default.cnf
+
 install:
   - go get -v github.com/Masterminds/glide
   - cd $GOPATH/src/github.com/Masterminds/glide && git checkout tags/v0.12.3 && go install && cd -


### PR DESCRIPTION
failed test mysql

```
go test -v .
2017/08/23 05:53:27 [error] setup test db: error: *** [/usr/bin/mysql_install_db --defaults-file=/tmp/mysqltest479513935/etc/my.cnf --basedir=/usr] failed ***
FATAL ERROR: Could not find my-default.cnf
```